### PR TITLE
Migrate python example to anaconda3

### DIFF
--- a/python-job/python.slurm
+++ b/python-job/python.slurm
@@ -10,7 +10,7 @@
 # Load the Anaconda distribution of Python, which comes
 # pre-bundled with many of the popular scientific computing tools like
 # numpy, scipy, pandas, scikit-learn, etc.
-module load Anaconda2
+module load Anaconda3
 
-# Pass your Python script to the Anaconda2 python intepreter for execution
+# Pass your Python script to the Anaconda3 python intepreter for execution
 python vectorization.py

--- a/python-job/vectorization.py
+++ b/python-job/vectorization.py
@@ -1,27 +1,28 @@
 #!/usr/bin/env python
-#
-# Python 2.7 script demonstrating vectorized execution
-#
+"""
+Python 3.6 script demonstrating vectorized execution
+"""
 import numpy as np
 import time
+
 
 # 10 million entries
 t = np.linspace(-10,10,10000000)
 x1 = np.zeros(len(t))
 x2 = np.zeros(len(t))
 
-time1 = time.clock()
+time1 = time.process_time()
 # naive, non-vectorized implementation
-for i,ti in enumerate(t):
-	x1[i] = np.sin(ti)
-time2 = time.clock()
-print '%s: %0.2f seconds elapsed' % ("naive implementation", time2-time1)
+for i, ti in enumerate(t):
+    x1[i] = np.sin(ti)
+time2 = time.process_time()
+print(f"naive implementation {time2-time1:.2f} cpu seconds elapsed")
 
 # vectorized implementation
-time1 = time.clock()
+time1 = time.process_time()
 x2 = np.sin(t)
-time2 = time.clock()
-print '%s: %0.2f seconds elapsed' % ("vectorized implementation", time2-time1)
+time2 = time.process_time()
+print(f"vectorized implementation {time2-time1:.2f} cpu seconds elapsed")
 
-if ( np.array_equal(x1,x2) ):
-	print "arrays equal!"
+if np.array_equal(x1,x2):
+	print("arrays equal!")


### PR DESCRIPTION
Use anaconda3 in python example script, and update the
script to use up to date python3 features including
f-strings.

Change time.clock to time.process_time as the former
is deprecated as of python 3.3.

See RT 37626 for motivation - @arnold-jr suggested steering users towards anaconda3